### PR TITLE
Fix check for :object_partial?

### DIFF
--- a/lib/turbo_flash/configuration.rb
+++ b/lib/turbo_flash/configuration.rb
@@ -23,7 +23,8 @@ module TurboFlash
     end
 
     def object_partial?
-      @partial.is_a?(String) && Object.const_defined?(@partial)
+      # check if the partial is a defined class
+      @partial.is_a?(String) && @partial.split('/').map(&:camelize).join('::').safe_constantize.present?
     end
   end
 end


### PR DESCRIPTION
I am guessing the point of that change was to support a component class handling the rendering of the partial. This was broken since `Object.const_defined?("partial_path_string")` gives an error unless the string starts with a capital letter. This is a bit safer but still not foolproof. It would probably be a better idea to extract this kind of functionality in a configuration setting so that users can opt-in to this explicitly.